### PR TITLE
compileTestKotlinCommon cacheability issue

### DIFF
--- a/dsl/jvm/api/mockk-dsl-jvm.api
+++ b/dsl/jvm/api/mockk-dsl-jvm.api
@@ -543,6 +543,7 @@ public final class io/mockk/MockKConstructorScope : io/mockk/MockKUnmockKScope {
 public final class io/mockk/MockKDsl {
 	public static final field INSTANCE Lio/mockk/MockKDsl;
 	public final fun internalCheckExactlyAtMostAtLeast (IIILio/mockk/Ordering;)V
+	public final fun internalCheckUnnecessaryStub ([Ljava/lang/Object;)V
 	public final fun internalClearAllMocks (ZZZZZZZZZ)V
 	public static synthetic fun internalClearAllMocks$default (Lio/mockk/MockKDsl;ZZZZZZZZZILjava/lang/Object;)V
 	public final fun internalClearConstructorMockk ([Lkotlin/reflect/KClass;ZZZZZ)V
@@ -756,6 +757,8 @@ public abstract interface class io/mockk/MockKGateway$Stubber {
 public abstract interface class io/mockk/MockKGateway$VerificationAcknowledger {
 	public abstract fun acknowledgeVerified ()V
 	public abstract fun acknowledgeVerified (Ljava/lang/Object;)V
+	public abstract fun checkUnnecessaryStub ()V
+	public abstract fun checkUnnecessaryStub (Ljava/lang/Object;)V
 	public abstract fun markCallVerified (Lio/mockk/Invocation;)V
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,8 @@
 version=1.12.5-SNAPSHOT
 org.gradle.configureondemand=false
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=768m
+org.gradle.parallel=true
+org.gradle.caching=true
 # localrepo=build/mockk-repo
 localrepo=/Users/raibaz/.m2/repository
 # kotlin.version=1.5.10

--- a/mockk/common/build.gradle.kts
+++ b/mockk/common/build.gradle.kts
@@ -13,6 +13,17 @@ java {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
+val buildScanApi = rootProject.extensions.getByType<com.gradle.scan.plugin.BuildScanExtension>()
+
+tasks.named<org.jetbrains.kotlin.gradle.tasks.KotlinCompileCommon>("compileTestKotlinCommon") {
+    doFirst {
+        filteredArgumentsMap.forEach { key, value ->
+            // attach custom values to the build scan
+            buildScanApi.value("$name#filteredArgumentsMap#$key", value)
+        }
+    }
+}
+
 dependencies {
     api(project(":mockk-dsl"))
 }

--- a/mockk/jvm/api/mockk-jvm.api
+++ b/mockk/jvm/api/mockk-jvm.api
@@ -20,6 +20,7 @@ public final class io/mockk/MockKAnnotations {
 }
 
 public final class io/mockk/MockKKt {
+	public static final fun checkUnnecessaryStub ([Ljava/lang/Object;)V
 	public static final fun clearAllMocks (ZZZZZZZ)V
 	public static synthetic fun clearAllMocks$default (ZZZZZZZILjava/lang/Object;)V
 	public static final fun clearConstructorMockk ([Lkotlin/reflect/KClass;ZZZ)V
@@ -733,6 +734,8 @@ public final class io/mockk/impl/recording/CommonVerificationAcknowledger : io/m
 	public fun <init> (Lio/mockk/impl/stub/StubRepository;Lio/mockk/impl/log/SafeToString;)V
 	public fun acknowledgeVerified ()V
 	public fun acknowledgeVerified (Ljava/lang/Object;)V
+	public fun checkUnnecessaryStub ()V
+	public fun checkUnnecessaryStub (Ljava/lang/Object;)V
 	public final fun getSafeToString ()Lio/mockk/impl/log/SafeToString;
 	public final fun getStubRepo ()Lio/mockk/impl/stub/StubRepository;
 	public fun markCallVerified (Lio/mockk/Invocation;)V
@@ -944,6 +947,7 @@ public final class io/mockk/impl/stub/ConstructorStub : io/mockk/impl/stub/Stub 
 	public fun getType ()Lkotlin/reflect/KClass;
 	public fun handleInvocation (Ljava/lang/Object;Lio/mockk/MethodDescription;Lkotlin/jvm/functions/Function0;[Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public fun markCallVerified (Lio/mockk/Invocation;)V
+	public fun matcherUsages ()Ljava/util/Map;
 	public fun recordCall (Lio/mockk/Invocation;)V
 	public fun stdObjectAnswer (Lio/mockk/Invocation;)Ljava/lang/Object;
 	public fun toStr ()Ljava/lang/String;
@@ -977,6 +981,7 @@ public class io/mockk/impl/stub/MockKStub : io/mockk/impl/stub/Stub {
 	public fun getType ()Lkotlin/reflect/KClass;
 	public fun handleInvocation (Ljava/lang/Object;Lio/mockk/MethodDescription;Lkotlin/jvm/functions/Function0;[Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public fun markCallVerified (Lio/mockk/Invocation;)V
+	public fun matcherUsages ()Ljava/util/Map;
 	public fun recordCall (Lio/mockk/Invocation;)V
 	public final fun setDisposeRoutine (Lkotlin/jvm/functions/Function0;)V
 	public final fun setHashCodeStr (Ljava/lang/String;)V
@@ -1017,6 +1022,7 @@ public abstract interface class io/mockk/impl/stub/Stub : io/mockk/impl/platform
 	public abstract fun getType ()Lkotlin/reflect/KClass;
 	public abstract fun handleInvocation (Ljava/lang/Object;Lio/mockk/MethodDescription;Lkotlin/jvm/functions/Function0;[Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public abstract fun markCallVerified (Lio/mockk/Invocation;)V
+	public abstract fun matcherUsages ()Ljava/util/Map;
 	public abstract fun recordCall (Lio/mockk/Invocation;)V
 	public abstract fun stdObjectAnswer (Lio/mockk/Invocation;)Ljava/lang/Object;
 	public abstract fun toStr ()Ljava/lang/String;
@@ -1117,6 +1123,7 @@ public final class io/mockk/junit4/MockKRule : org/junit/rules/TestWatcher, org/
 }
 
 public final class io/mockk/junit5/MockKExtension : org/junit/jupiter/api/extension/AfterAllCallback, org/junit/jupiter/api/extension/ParameterResolver, org/junit/jupiter/api/extension/TestInstancePostProcessor {
+	public static final field CHECK_UNNECESSARY_STUB_PROPERTY Ljava/lang/String;
 	public static final field CONFIRM_VERIFICATION_PROPERTY Ljava/lang/String;
 	public static final field Companion Lio/mockk/junit5/MockKExtension$Companion;
 	public static final field KEEP_MOCKS_PROPERTY Ljava/lang/String;
@@ -1127,13 +1134,13 @@ public final class io/mockk/junit5/MockKExtension : org/junit/jupiter/api/extens
 	public fun supportsParameter (Lorg/junit/jupiter/api/extension/ParameterContext;Lorg/junit/jupiter/api/extension/ExtensionContext;)Z
 }
 
+public abstract interface annotation class io/mockk/junit5/MockKExtension$CheckUnnecessaryStub : java/lang/annotation/Annotation {
+}
+
 public final class io/mockk/junit5/MockKExtension$Companion {
 }
 
 public abstract interface annotation class io/mockk/junit5/MockKExtension$ConfirmVerification : java/lang/annotation/Annotation {
-}
-
-public abstract interface annotation class io/mockk/junit5/MockKExtension$CheckUnnecessaryStub : java/lang/annotation/Annotation {
 }
 
 public abstract interface annotation class io/mockk/junit5/MockKExtension$KeepMocks : java/lang/annotation/Annotation {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,7 +15,7 @@ gradleEnterprise {
     buildScan {
         termsOfServiceUrl = "https://gradle.com/terms-of-service"
         termsOfServiceAgree = "yes"
-        publishAlways()
+//        publishAlways()
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,9 +15,21 @@ gradleEnterprise {
     buildScan {
         termsOfServiceUrl = "https://gradle.com/terms-of-service"
         termsOfServiceAgree = "yes"
-//        publishAlways()
+    }
+
+    buildCache {
+        local {
+            isEnabled = true
+            isPush = true
+            directory = getLocalBuildCacheDirectory()
+        }
     }
 }
+
+fun getLocalBuildCacheDirectory() =
+    gradle.startParameter.projectProperties["build.cache.root"]
+        ?.let { File(it, "build-cache") }
+        ?.also { logger.quiet("Custom build cache location: $it") }
 
 apply(from = "gradle/detect-android-sdk.gradle")
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,6 +6,19 @@ pluginManagement {
     }
 }
 
+plugins {
+    id("com.gradle.enterprise") version "3.10.2"
+    id("com.gradle.common-custom-user-data-gradle-plugin") version "1.7.2"
+}
+
+gradleEnterprise {
+    buildScan {
+        termsOfServiceUrl = "https://gradle.com/terms-of-service"
+        termsOfServiceAgree = "yes"
+        publishAlways()
+    }
+}
+
 apply(from = "gradle/detect-android-sdk.gradle")
 
 rootProject.name = "mockk-root"


### PR DESCRIPTION
Reproducer for the [KT-53110](https://youtrack.jetbrains.com/issue/KT-53110/KotlinCompileCommon-cache-results-are-not-relocatable-across-different-workspaces).